### PR TITLE
Fixing the crash happened due to low disk memory while writing the logs

### DIFF
--- a/swaylortift/swaylortift.xcodeproj/project.pbxproj
+++ b/swaylortift/swaylortift.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		5BA64DC822F9693D006735E9 /* FrequencyTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA64DA722F9693D006735E9 /* FrequencyTable.swift */; };
 		5BA64DC922F9693D006735E9 /* SortedArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA64DA822F9693D006735E9 /* SortedArray.swift */; };
 		78369F9FA39DCA1705557BB9 /* SetOnceFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78369785328F923C6B7F1DB8 /* SetOnceFlag.swift */; };
+		9253441826007D17003FA95E /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9253441726007D17003FA95E /* FileManager.swift */; };
 		EC530B71C26F69DC7FDDBC22 /* Pods_SwaylorTift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67BEE1635C80D29160D8BEC6 /* Pods_SwaylorTift.framework */; };
 /* End PBXBuildFile section */
 
@@ -103,6 +104,7 @@
 		67BEE1635C80D29160D8BEC6 /* Pods_SwaylorTift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwaylorTift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		78369785328F923C6B7F1DB8 /* SetOnceFlag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetOnceFlag.swift; sourceTree = "<group>"; };
 		833D65D8551BC8142ECF32E7 /* Pods-SwaylorTift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwaylorTift.debug.xcconfig"; path = "Target Support Files/Pods-SwaylorTift/Pods-SwaylorTift.debug.xcconfig"; sourceTree = "<group>"; };
+		9253441726007D17003FA95E /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileManager.swift; path = ../../../../swaylortift/swaylortift/Source/Extensions/FileManager.swift; sourceTree = "<group>"; };
 		E41BA6CF95F677E881353D0C /* Pods-SwaylorTiftTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwaylorTiftTests.release.xcconfig"; path = "Target Support Files/Pods-SwaylorTiftTests/Pods-SwaylorTiftTests.release.xcconfig"; sourceTree = "<group>"; };
 		E4802AFDD5D11750CD14771D /* Pods-SwaylorTift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwaylorTift.release.xcconfig"; path = "Target Support Files/Pods-SwaylorTift/Pods-SwaylorTift.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -236,6 +238,7 @@
 				5BA64D9D22F9693C006735E9 /* UIDevice.swift */,
 				5BA64D9622F9693C006735E9 /* UInt.swift */,
 				5BA64D9422F9693C006735E9 /* UIView.swift */,
+				9253441726007D17003FA95E /* FileManager.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -457,6 +460,7 @@
 				5BA64DB422F9693D006735E9 /* File.swift in Sources */,
 				5BA64DB222F9693D006735E9 /* JSON.swift in Sources */,
 				5BA64DC222F9693D006735E9 /* Double.swift in Sources */,
+				9253441826007D17003FA95E /* FileManager.swift in Sources */,
 				5BA64DC822F9693D006735E9 /* FrequencyTable.swift in Sources */,
 				5BA64DAB22F9693D006735E9 /* Delay.swift in Sources */,
 				5BA64DB822F9693D006735E9 /* UInt.swift in Sources */,

--- a/swaylortift/swaylortift/Source/Extensions/FileManager.swift
+++ b/swaylortift/swaylortift/Source/Extensions/FileManager.swift
@@ -1,0 +1,50 @@
+/*    ____                 __           _______ _____
+*   / __/    _____ ___ __/ /__  ____  /_  __(_) _/ /_
+*  _\ \| |/|/ / _ `/ // / / _ \/ __/   / / / / _/ __/
+* /___/|__,__/\_,_/\_, /_/\___/_/     /_/ /_/_/ \__/
+*                 /___/
+* Utils & Extensions for Swift Projects
+* (c) 2018 Ciathyza
+*/
+
+import Foundation
+
+extension FileManager
+{
+	///
+	/// Returns free disk space in MB.
+	///
+	public func availableDiskSpaceInMB() -> Int64
+	{
+		let freeSizeResult = FileManager.default.systemFreeSizeBytes()
+		switch freeSizeResult
+		{
+		case .failure(let error):
+			Log.error(category: SWAYLOR_TIFT_NAME, error)
+			return 0
+		case .success(let freeSize):
+			let freeSpaceInMB = freeSize / (1024*1024)
+			return freeSpaceInMB
+		}
+	}
+
+	///
+	/// Returns free disk space in Bytes.
+	///
+	public func systemFreeSizeBytes() -> Result<Int64, Error>
+	{
+		do
+		{
+			let attrs = try attributesOfFileSystem(forPath: NSHomeDirectory())
+			guard let freeSize = attrs[.systemFreeSize] as? Int64 else
+			{
+				return .failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey : "Can't retrieve system free size"]))
+			}
+			return .success(freeSize)
+		}
+		catch
+		{
+			return .failure(error)
+		}
+	}
+}

--- a/swaylortift/swaylortift/Source/Util/Log.swift
+++ b/swaylortift/swaylortift/Source/Util/Log.swift
@@ -260,7 +260,7 @@ public struct Log
 
 		Swift.print(line, terminator: Log.terminator)
 
-		// check if 100MB  free memory is available
+		// check if minFreeDiskSpaceRequired condition is met
 		guard FileManager.default.availableDiskSpaceInMB() > Log.minFreeDiskSpaceRequired else
 		{
 			if Log.enabled && Log.fileLoggingEnabled
@@ -272,7 +272,7 @@ public struct Log
 			}
 			return
 		}
-		
+
 
 		log(line)
 	}

--- a/swaylortift/swaylortift/Source/Util/Log.swift
+++ b/swaylortift/swaylortift/Source/Util/Log.swift
@@ -63,6 +63,9 @@ public struct Log
 	public static var separator          = String.Space
 	public static var terminator         = String.LF
 
+	// Minimum free disk space required (in MB) to write to log file.
+	public static var minFreeDiskSpaceRequired: Int64  = 100
+
 	public static var logFilePath: String?
 	public static var logFile: LogFile?
 
@@ -223,6 +226,18 @@ public struct Log
 		let line = "\(Log.prompt)\(Log.getLogLevelName(logLevel))\(cat)\(prefix)\(itemsString)"
 
 		Swift.print(line, terminator: Log.terminator)
+
+		// check if 100MB  free memory is available
+		guard FileManager.default.availableDiskSpaceInMB() > Log.minFreeDiskSpaceRequired else
+		{
+			if Log.enabled
+			{
+				Swift.print("\(SWAYLOR_TIFT_NAME) [ERROR] : Unable to write logs.Disk memory less than 100MB.", terminator: Log.terminator)
+				// Disable logs if Logs are enabled and Disk free space is less than the `minFreeDiskSpaceRequired`
+				Log.enabled = false
+			}
+			return
+		}
 
 		if let logFilePath = Log.logFilePath
 		{

--- a/swaylortift/swaylortift/Source/Util/Log.swift
+++ b/swaylortift/swaylortift/Source/Util/Log.swift
@@ -272,8 +272,7 @@ public struct Log
 			}
 			return
 		}
-
-
+		
 		log(line)
 	}
 


### PR DESCRIPTION
In this PR:

- Added check for free disk space before writing the log to a log file. 
- Disabling the file logging once the free space falls below the set minimum free space required. Default is set to 100MB. Logging will happen on xcode console even on low disk memory situation.